### PR TITLE
Native macOS/Linux support (ucontext thread scheduler, fullscreen, build fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,21 +79,31 @@ picker contract but also prompt for a legally obtained game disc image.
 
 ## Setup
 
+Builds natively on **Windows (MSVC/MinGW)**, **macOS (Apple Silicon & Intel)**,
+and **Linux**. The BIOS thread scheduler uses host fibers — Win32 Fibers on
+Windows, `ucontext` on POSIX (`runtime/src/psx_fiber.c`) — so the recompiled
+BIOS's cooperative thread switching (the CD-boot handoff in particular) behaves
+the same on every platform.
+
 Requirements:
 
-- Windows 10/11 x64.
-- MSYS2 with the `mingw-w64-x86_64` toolchain, CMake 3.20+, and SDL2.
+- A C/C++ toolchain: MSVC or MinGW (Windows), Apple Clang (macOS), Clang/GCC (Linux).
+- CMake 3.20+. On macOS/Linux also `ninja` and `pkg-config`.
+- SDL2: the bundled dev pack on Windows; `brew install sdl2 pkg-config ninja`
+  on macOS; `libsdl2-dev` (or distro equivalent) on Linux.
 - A legally obtained `SCPH1001.BIN` BIOS dump. Not included.
 - For game projects, a legally obtained game disc/EXE dump. Not included.
 
 Build the framework runtime:
 
 ```sh
-cd F:/Projects/psxrecomp-v4
-cmake -S recompiler -B recompiler/build -G "Unix Makefiles"
-cmake --build recompiler/build
-cmake -S runtime -B runtime/build -G "Unix Makefiles"
-cmake --build runtime/build --target psx-runtime
+# Windows (MSYS2/MinGW)
+cmake -S recompiler -B recompiler/build -G "Unix Makefiles" && cmake --build recompiler/build
+cmake -S runtime    -B runtime/build    -G "Unix Makefiles" && cmake --build runtime/build --target psx-runtime
+
+# macOS / Linux (Ninja)
+cmake -S recompiler -B recompiler/build -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C recompiler/build
+cmake -S runtime    -B runtime/build    -G Ninja -DCMAKE_BUILD_TYPE=Release && ninja -C runtime/build psx-runtime
 ```
 
 Game projects generate their own `generated/<serial>_*.c` files and link this
@@ -113,6 +123,7 @@ runtime source tree through CMake.
 | Start | Enter |
 | Select | Right Shift |
 | Turbo | Tab (hold) |
+| Fullscreen | F11 / Alt+Enter / Cmd+F |
 
 ## Controller Map
 

--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -5,6 +5,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(lib/fmt)
 
+# Vendored fmt 9.1.0 enables its `consteval` format-string check on Apple
+# clang via the `__cpp_consteval` clause in core.h, even though the same
+# block tries to exclude Apple toolchains — and Apple clang 21 then rejects
+# fmt's own literal format strings ("call to consteval function is not a
+# constant expression"). Force FMT_CONSTEVAL empty to take fmt's
+# non-consteval compile-time-check path. Scoped to non-MSVC so Windows is
+# untouched.
+if(NOT MSVC)
+    target_compile_definitions(fmt PUBLIC FMT_CONSTEVAL=)
+endif()
+
 # Rabbitizer MIPS decoder
 add_library(rabbitizer STATIC)
 target_sources(rabbitizer PRIVATE

--- a/runtime/include/psx_fiber.h
+++ b/runtime/include/psx_fiber.h
@@ -1,0 +1,55 @@
+/*
+ * psx_fiber.h — cross-platform cooperative fibers for the BIOS thread
+ * scheduler (traps.c) and exception-deferral (interrupts.c).
+ *
+ * The PS1 BIOS manages its own threads (TCBs) and switches between them
+ * cooperatively; the runtime mirrors each BIOS thread with a host fiber so
+ * the recompiled C for a suspended thread keeps its own native call stack
+ * across a ChangeThread. The CD-boot handoff in particular depends on this:
+ * a thread issues a CD command, WaitEvent-blocks, and the scheduler must be
+ * able to resume a *different* thread's previously-suspended stack — which
+ * requires real separate stacks, not nested dispatch.
+ *
+ * Backends:
+ *   - Windows: the Win32 Fiber API (ConvertThreadToFiber / CreateFiber /
+ *     SwitchToFiber / DeleteFiber). Behavior is identical to the original.
+ *   - POSIX (macOS/Linux): ucontext (makecontext / swapcontext).
+ *
+ * Cooperative, single-threaded: exactly one fiber runs at a time and all
+ * switches are explicit. psx_fiber_current() is the GetCurrentFiber analog.
+ */
+#ifndef PSX_FIBER_H
+#define PSX_FIBER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* psx_fiber_t;
+typedef void (*psx_fiber_entry)(void* arg);
+
+/* Make the current thread a fiber so it can switch to others. Idempotent;
+ * returns the handle for the current thread's fiber. Call before the first
+ * psx_fiber_switch on this thread. */
+psx_fiber_t psx_fiber_convert_thread(void);
+
+/* The currently-executing fiber (GetCurrentFiber analog). */
+psx_fiber_t psx_fiber_current(void);
+
+/* Create a fiber with its own stack. It does not run until switched to. */
+psx_fiber_t psx_fiber_create(size_t stack_size, psx_fiber_entry entry, void* arg);
+
+/* Switch execution to target; the caller is suspended until switched back. */
+void psx_fiber_switch(psx_fiber_t target);
+
+/* Destroy a fiber created by psx_fiber_create and free its stack. Must not
+ * be the currently-running fiber. */
+void psx_fiber_destroy(psx_fiber_t fiber);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PSX_FIBER_H */

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -49,6 +49,7 @@ set(PSXRECOMP_V4_RUNTIME_SOURCES
     ${PSXRECOMP_V4_ROOT}/runtime/src/mdec.c
     ${PSXRECOMP_V4_ROOT}/runtime/src/timers.c
     ${PSXRECOMP_V4_ROOT}/runtime/src/interrupts.c
+    ${PSXRECOMP_V4_ROOT}/runtime/src/psx_fiber.c
     ${PSXRECOMP_V4_ROOT}/runtime/src/sio.c
     ${PSXRECOMP_V4_ROOT}/runtime/src/memcard.c
     ${PSXRECOMP_V4_ROOT}/runtime/src/debug_server.c
@@ -140,6 +141,12 @@ function(psxrecomp_v4_add_runtime_target target)
         ${PSXRECOMP_V4_RUNTIME_INCLUDE_DIRS}
         ${SDL2_INCLUDE_DIRS}
     )
+    # pkg-config reports SDL2_LIBRARIES as a bare name (e.g. "SDL2" -> -lSDL2);
+    # add its library dirs so the linker finds it outside default paths
+    # (e.g. Homebrew's /opt/homebrew/lib on macOS). Empty/harmless on MSVC.
+    if(SDL2_LIBRARY_DIRS)
+        target_link_directories(${target} PRIVATE ${SDL2_LIBRARY_DIRS})
+    endif()
     target_link_libraries(${target} PRIVATE ${SDL2_LIBRARIES})
 
     target_compile_definitions(${target} PRIVATE

--- a/runtime/src/crash_trace.c
+++ b/runtime/src/crash_trace.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>   /* va_start/va_end — not pulled in transitively off Windows */
 #include <time.h>
 
 #include "cpu_state.h"

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -93,10 +93,12 @@ static int post_exception_cooldown;
  * That fiber's wrapped SwitchToFiber call will observe the flag on
  * return and execute the longjmp on the correct stack. */
 jmp_buf exception_jmpbuf;  /* non-static so traps.c can deferred-longjmp */
-#ifdef _WIN32
+/* The fiber that owns the current exception setjmp. A longjmp must run on
+ * that same fiber/stack, so a non-owner defers by switching back to it
+ * first (see deferred_exception_longjmp). Used on all platforms now that
+ * the thread scheduler is fiber-based everywhere. */
 void* g_exception_owner_fiber = NULL;
 int   g_pending_exception_longjmp = 0;
-#endif
 extern int g_psx_dispatch_depth;
 
 int psx_get_in_exception(void) { return in_exception; }
@@ -139,29 +141,23 @@ void interrupts_init(void) {
  * in_exception and return, effectively letting the interrupted
  * code resume at the saved EPC through normal dispatch.
  */
-#ifdef _WIN32
-#include <windows.h>
+#include "psx_fiber.h"
 /* Defer a longjmp to the fiber that owns the current exception setjmp.
  * If we're on the owning fiber already, longjmp immediately. Otherwise
- * record the requested code, SwitchToFiber back to the owner, and the
- * post-SwitchToFiber check in traps.c psx_change_thread_fiber (or the
- * fiber entry helper) will execute the longjmp on the correct stack. */
+ * record the requested code, switch back to the owner, and the post-switch
+ * check in traps.c psx_change_thread_fiber executes the longjmp on the
+ * correct stack. */
 static void deferred_exception_longjmp(int code) {
-    if (!g_exception_owner_fiber || GetCurrentFiber() == g_exception_owner_fiber) {
+    if (!g_exception_owner_fiber || psx_fiber_current() == g_exception_owner_fiber) {
         longjmp(exception_jmpbuf, code);
     }
     g_pending_exception_longjmp = code;
-    SwitchToFiber(g_exception_owner_fiber);
+    psx_fiber_switch(g_exception_owner_fiber);
     /* If we end up back here, the owner didn't honor the flag (bug).
      * Fall through to direct longjmp as a last resort — even though
      * the stack is wrong, the alternative is hanging silently. */
     longjmp(exception_jmpbuf, code);
 }
-#else
-static void deferred_exception_longjmp(int code) {
-    longjmp(exception_jmpbuf, code);
-}
-#endif
 
 void psx_exception_longjmp(void) {
     debug_server_log_restore_event(2, debug_cpu_ptr ? debug_cpu_ptr->pc : 0, 1);
@@ -345,15 +341,13 @@ void psx_check_interrupts(CPUState* cpu) {
         target_pc = hi_val + (uint32_t)(int32_t)lo_val;
     }
 
-#ifdef _WIN32
     /* Record which fiber owns this setjmp. Any subsequent longjmp must
      * happen on this same fiber; if a non-owner fiber needs to longjmp
-     * it must SwitchToFiber back here first (see deferred_exception_longjmp). */
+     * it must switch back here first (see deferred_exception_longjmp). */
     void *prev_owner_fiber = g_exception_owner_fiber;
     int   prev_pending = g_pending_exception_longjmp;
-    g_exception_owner_fiber = GetCurrentFiber();
+    g_exception_owner_fiber = psx_fiber_current();
     g_pending_exception_longjmp = 0;
-#endif
     for (;;) {
         int jmp_val = setjmp(exception_jmpbuf);
         if (jmp_val == 2) {
@@ -376,12 +370,10 @@ void psx_check_interrupts(CPUState* cpu) {
         /* jmp_val 0 (normal return) or 1 (ReturnFromException): done. */
         break;
     }
-#ifdef _WIN32
     /* Restore previous exception-owner state. Supports nested exceptions
      * if they ever arise (uncommon but harmless). */
     g_exception_owner_fiber = prev_owner_fiber;
     g_pending_exception_longjmp = prev_pending;
-#endif
 
     /* Restore the interrupted code's registers.
      *

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -907,6 +907,19 @@ static void sdl_vblank_present(void) {
                 close_controller();
                 open_configured_controller();
             }
+        } else if (ev.type == SDL_KEYDOWN) {
+            /* Fullscreen toggle: F11, Alt+Enter, or Cmd/Ctrl+F.
+             * FULLSCREEN_DESKTOP keeps the desktop resolution; the
+             * renderer's logical size letterboxes the 640x480 image. */
+            const Uint16 mod = ev.key.keysym.mod;
+            if (ev.key.keysym.sym == SDLK_F11 ||
+                (ev.key.keysym.sym == SDLK_RETURN && (mod & KMOD_ALT)) ||
+                (ev.key.keysym.sym == SDLK_f && (mod & (KMOD_GUI | KMOD_CTRL)))) {
+                Uint32 is_fs = SDL_GetWindowFlags(sdl_window) &
+                               SDL_WINDOW_FULLSCREEN_DESKTOP;
+                SDL_SetWindowFullscreen(sdl_window,
+                    is_fs ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
+            }
         }
     }
 
@@ -1171,12 +1184,26 @@ int main(int argc, char** argv) {
      * Note: the freeze became prevalent only after the FMV-speed fix
      * (commit b486c13) raised cycle throughput. Before that, the slower
      * MDEC/DMA workload was below whatever GDI threshold trips the bug. */
+    /* The OpenGL force above is a Windows-only workaround for the GDI
+     * presentation hang; macOS/Linux have no GDI path, so let SDL choose its
+     * native backend (Metal on Apple Silicon). PRESENTVSYNC removes tearing;
+     * fall back progressively if a driver can't provide vsync/accel. */
+#ifdef _WIN32
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
-    sdl_renderer = SDL_CreateRenderer(sdl_window, -1, SDL_RENDERER_ACCELERATED);
+#endif
+    sdl_renderer = SDL_CreateRenderer(sdl_window, -1,
+        SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!sdl_renderer)
+        sdl_renderer = SDL_CreateRenderer(sdl_window, -1, SDL_RENDERER_ACCELERATED);
     if (!sdl_renderer) {
         std::fprintf(stderr, "SDL_CreateRenderer failed: %s\n", SDL_GetError());
         return 1;
     }
+
+    /* Present in a fixed 640x480 logical space; SDL scales (and, in
+     * fullscreen, letterboxes) it to the real output. Identity in the
+     * default 640x480 window, so windowed rendering is unchanged. */
+    SDL_RenderSetLogicalSize(sdl_renderer, 640, 480);
 
     sdl_texture = SDL_CreateTexture(
         sdl_renderer,

--- a/runtime/src/psx_fiber.c
+++ b/runtime/src/psx_fiber.c
@@ -1,0 +1,122 @@
+/*
+ * psx_fiber.c — Win32-Fiber / POSIX-ucontext backends for psx_fiber.h.
+ */
+#include "psx_fiber.h"
+
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+psx_fiber_t psx_fiber_convert_thread(void)
+{
+    /* If already a fiber, GetCurrentFiber returns it; otherwise convert.
+     * On a freshly-converted thread GetCurrentFiber == the new fiber. */
+    void* cur = GetCurrentFiber();
+    /* 0 and 0x1E00000000000000 are the documented "not a fiber" sentinels. */
+    if (cur == NULL || cur == (void*)(uintptr_t)0x1E00000000000000ULL) {
+        cur = ConvertThreadToFiber(NULL);
+    }
+    return (psx_fiber_t)cur;
+}
+
+psx_fiber_t psx_fiber_current(void)      { return (psx_fiber_t)GetCurrentFiber(); }
+
+psx_fiber_t psx_fiber_create(size_t stack_size, psx_fiber_entry entry, void* arg)
+{
+    return (psx_fiber_t)CreateFiber((SIZE_T)stack_size,
+                                    (LPFIBER_START_ROUTINE)entry, arg);
+}
+
+void psx_fiber_switch(psx_fiber_t target) { SwitchToFiber((LPVOID)target); }
+void psx_fiber_destroy(psx_fiber_t fiber) { if (fiber) DeleteFiber((LPVOID)fiber); }
+
+#else /* POSIX: ucontext */
+
+#ifndef _XOPEN_SOURCE
+#  define _XOPEN_SOURCE 700
+#endif
+#ifdef __APPLE__
+#  define _DARWIN_C_SOURCE 1
+#endif
+
+#include <ucontext.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#if defined(__clang__) || defined(__GNUC__)
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+typedef struct psx_fiber_impl {
+    ucontext_t      ctx;
+    void*           stack;    /* NULL for the thread-fiber */
+    psx_fiber_entry entry;
+    void*           arg;
+} psx_fiber_impl;
+
+/* Cooperative + single-threaded, so a plain static tracks who's running. */
+static psx_fiber_impl* s_current = NULL;
+
+/* makecontext only passes ints; split the fiber pointer across two. */
+static void psx_fiber_trampoline(unsigned int hi, unsigned int lo)
+{
+    uintptr_t p = ((uintptr_t)hi << 32) | (uintptr_t)lo;
+    psx_fiber_impl* f = (psx_fiber_impl*)p;
+    f->entry(f->arg);
+    /* The BIOS thread entry never returns normally (it switches back to its
+     * scheduler target, or trap_crashes). Reaching here is a bug. */
+    abort();
+}
+
+psx_fiber_t psx_fiber_convert_thread(void)
+{
+    if (!s_current) {
+        psx_fiber_impl* f = (psx_fiber_impl*)calloc(1, sizeof(*f));
+        f->stack = NULL;       /* runs on the real thread stack */
+        s_current = f;
+    }
+    return (psx_fiber_t)s_current;
+}
+
+psx_fiber_t psx_fiber_current(void) { return (psx_fiber_t)s_current; }
+
+psx_fiber_t psx_fiber_create(size_t stack_size, psx_fiber_entry entry, void* arg)
+{
+    if (stack_size < SIGSTKSZ) stack_size = SIGSTKSZ;
+    psx_fiber_impl* f = (psx_fiber_impl*)calloc(1, sizeof(*f));
+    if (!f) return NULL;
+    f->stack = malloc(stack_size);
+    if (!f->stack) { free(f); return NULL; }
+    f->entry = entry;
+    f->arg   = arg;
+    if (getcontext(&f->ctx) != 0) { free(f->stack); free(f); return NULL; }
+    f->ctx.uc_stack.ss_sp   = f->stack;
+    f->ctx.uc_stack.ss_size = stack_size;
+    f->ctx.uc_link          = NULL;   /* entry never returns; see trampoline */
+    uintptr_t p = (uintptr_t)f;
+    makecontext(&f->ctx, (void (*)(void))psx_fiber_trampoline, 2,
+                (unsigned int)(p >> 32), (unsigned int)(p & 0xFFFFFFFFu));
+    return (psx_fiber_t)f;
+}
+
+void psx_fiber_switch(psx_fiber_t target)
+{
+    psx_fiber_impl* to   = (psx_fiber_impl*)target;
+    psx_fiber_impl* from = s_current;
+    if (!to || to == from) return;
+    s_current = to;
+    swapcontext(&from->ctx, &to->ctx);
+    /* Resumed: s_current was set back to `from` by whoever switched here. */
+}
+
+void psx_fiber_destroy(psx_fiber_t fiber)
+{
+    psx_fiber_impl* f = (psx_fiber_impl*)fiber;
+    if (!f) return;
+    free(f->stack);
+    free(f);
+}
+
+#endif /* _WIN32 */

--- a/runtime/src/traps.c
+++ b/runtime/src/traps.c
@@ -10,10 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
+#include "psx_fiber.h"   /* cross-platform fibers (Win32 fibers / POSIX ucontext) */
 
 /* Forward declarations from interrupts.c */
 int psx_get_in_exception(void);
@@ -26,14 +23,6 @@ static void trap_crash(const char* msg) {
     extern void psx_crash_trace_dump(const char *reason, void *seh_info);
     psx_crash_trace_dump("trap_crash", NULL);
 }
-
-typedef struct ThreadWaitFrame {
-    uint32_t tcb;
-    jmp_buf jmp;
-} ThreadWaitFrame;
-
-static ThreadWaitFrame s_thread_wait_stack[16];
-static int s_thread_wait_depth;
 
 static int psx_is_valid_tcb(CPUState* cpu, uint32_t tcb)
 {
@@ -135,12 +124,10 @@ static uint32_t psx_restore_context_from_tcb(CPUState* cpu, uint32_t tcb)
     return cpu->gpr[26];
 }
 
-#ifdef _WIN32
-
 typedef struct HostThreadFiber {
     uint32_t tcb;
-    LPVOID fiber;
-    LPVOID return_fiber;
+    psx_fiber_t fiber;
+    psx_fiber_t return_fiber;
     uint32_t return_tcb;
     CPUState* cpu;
     int used;
@@ -149,23 +136,23 @@ typedef struct HostThreadFiber {
 } HostThreadFiber;
 
 static HostThreadFiber s_host_threads[32];
-static LPVOID s_main_fiber;
+static psx_fiber_t s_main_fiber;
 
 static uint32_t psx_tcb_state(CPUState* cpu, uint32_t tcb)
 {
     return psx_is_valid_tcb(cpu, tcb) ? cpu->read_word(tcb) : 0;
 }
 
-static LPVOID psx_current_host_fiber(void)
+static psx_fiber_t psx_current_host_fiber(void)
 {
     if (!s_main_fiber) {
-        s_main_fiber = ConvertThreadToFiber(NULL);
+        s_main_fiber = psx_fiber_convert_thread();
         if (!s_main_fiber) {
-            trap_crash("ConvertThreadToFiber failed");
+            trap_crash("psx_fiber_convert_thread failed");
             exit(1);
         }
     }
-    return GetCurrentFiber();
+    return psx_fiber_current();
 }
 
 static HostThreadFiber* psx_find_host_thread(uint32_t tcb)
@@ -193,7 +180,7 @@ static HostThreadFiber* psx_alloc_host_thread(void)
 
 static HostThreadFiber* psx_bind_current_host_thread(CPUState* cpu, uint32_t tcb)
 {
-    LPVOID fiber = psx_current_host_fiber();
+    psx_fiber_t fiber = psx_current_host_fiber();
     HostThreadFiber* slot = psx_find_host_thread(tcb);
     if (!slot) {
         slot = psx_alloc_host_thread();
@@ -207,7 +194,7 @@ static HostThreadFiber* psx_bind_current_host_thread(CPUState* cpu, uint32_t tcb
     return slot;
 }
 
-static VOID CALLBACK psx_thread_fiber_entry(LPVOID param)
+static void psx_thread_fiber_entry(void* param)
 {
     HostThreadFiber* slot = (HostThreadFiber*)param;
     CPUState* cpu = slot->cpu;
@@ -231,7 +218,7 @@ static VOID CALLBACK psx_thread_fiber_entry(LPVOID param)
             (void)psx_restore_context_from_tcb(cpu, slot->return_tcb);
         }
         debug_server_log_thread_event(12, cpu, slot->tcb, slot->return_tcb, 0);
-        SwitchToFiber(slot->return_fiber);
+        psx_fiber_switch(slot->return_fiber);
     }
 
     trap_crash("BIOS thread fiber returned with no scheduler target");
@@ -251,8 +238,8 @@ static HostThreadFiber* psx_get_or_create_host_thread(CPUState* cpu, uint32_t tc
 
     if (!slot) {
         slot = psx_alloc_host_thread();
-    } else if (slot->fiber && slot->owned && slot->fiber != GetCurrentFiber()) {
-        DeleteFiber(slot->fiber);
+    } else if (slot->fiber && slot->owned && slot->fiber != psx_fiber_current()) {
+        psx_fiber_destroy(slot->fiber);
         slot->fiber = NULL;
     }
 
@@ -262,9 +249,9 @@ static HostThreadFiber* psx_get_or_create_host_thread(CPUState* cpu, uint32_t tc
     slot->return_tcb = 0;
     slot->owned = 1;
     slot->closed = 0;
-    slot->fiber = CreateFiber(1024 * 1024, psx_thread_fiber_entry, slot);
+    slot->fiber = psx_fiber_create(1024 * 1024, psx_thread_fiber_entry, slot);
     if (!slot->fiber) {
-        trap_crash("CreateFiber failed for BIOS thread");
+        trap_crash("psx_fiber_create failed for BIOS thread");
         exit(1);
     }
     return slot;
@@ -311,9 +298,9 @@ static int psx_change_thread_fiber(CPUState* cpu, uint32_t target_tcb)
     psx_set_current_tcb(cpu, target_tcb);
     (void)psx_restore_context_from_tcb(cpu, target_tcb);
     debug_server_log_thread_event(8, cpu, current_tcb, target_tcb, 0);
-    SwitchToFiber(target->fiber);
+    psx_fiber_switch(target->fiber);
 
-    /* SwitchToFiber returns on the original native stack, but CPUState is
+    /* The switch returns on the original native stack, but CPUState is
      * shared globally and still contains the fiber that just yielded back.
      * Restore the TCB we saved above before continuing on this stack. */
     if (saved_current_context && psx_is_valid_tcb(cpu, current_tcb)) {
@@ -327,7 +314,7 @@ static int psx_change_thread_fiber(CPUState* cpu, uint32_t target_tcb)
     extern void* g_exception_owner_fiber;
     extern int   g_pending_exception_longjmp;
     extern jmp_buf exception_jmpbuf;
-    if (g_pending_exception_longjmp && GetCurrentFiber() == g_exception_owner_fiber) {
+    if (g_pending_exception_longjmp && psx_fiber_current() == g_exception_owner_fiber) {
         int code = g_pending_exception_longjmp;
         g_pending_exception_longjmp = 0;
         longjmp(exception_jmpbuf, code);
@@ -338,70 +325,14 @@ static int psx_change_thread_fiber(CPUState* cpu, uint32_t target_tcb)
     return 1;
 }
 
-#endif
-
-static int psx_change_thread_setjmp(CPUState* cpu, uint32_t target_tcb)
-{
-    uint32_t current_tcb = psx_current_tcb_ptr(cpu);
-    if (!psx_is_valid_tcb(cpu, current_tcb) || !psx_is_valid_tcb(cpu, target_tcb)) {
-        return 0;
-    }
-    if (current_tcb == target_tcb) {
-        cpu->pc = 0;
-        return 1;
-    }
-
-    psx_save_context_to_tcb(cpu, current_tcb, cpu->gpr[31]);
-
-    if (s_thread_wait_depth > 0 &&
-        s_thread_wait_stack[s_thread_wait_depth - 1].tcb == target_tcb) {
-        ThreadWaitFrame *frame = &s_thread_wait_stack[s_thread_wait_depth - 1];
-        s_thread_wait_depth--;
-        psx_set_current_tcb(cpu, target_tcb);
-        (void)psx_restore_context_from_tcb(cpu, target_tcb);
-        cpu->pc = 0;
-        longjmp(frame->jmp, 1);
-    }
-
-    if (s_thread_wait_depth >= (int)(sizeof(s_thread_wait_stack) / sizeof(s_thread_wait_stack[0]))) {
-        trap_crash("ChangeThread wait stack overflow");
-        exit(1);
-    }
-
-    int frame_index = s_thread_wait_depth++;
-    ThreadWaitFrame *frame = &s_thread_wait_stack[frame_index];
-    frame->tcb = current_tcb;
-
-    if (setjmp(frame->jmp) != 0) {
-        cpu->pc = 0;
-        return 1;
-    }
-
-    psx_set_current_tcb(cpu, target_tcb);
-    uint32_t target_pc = psx_restore_context_from_tcb(cpu, target_tcb);
-    if (target_pc != 0) {
-        psx_dispatch(cpu, target_pc);
-    }
-
-    if (s_thread_wait_depth > frame_index &&
-        s_thread_wait_stack[frame_index].tcb == current_tcb) {
-        s_thread_wait_depth = frame_index;
-    }
-    if (psx_current_tcb_ptr(cpu) != current_tcb) {
-        psx_set_current_tcb(cpu, current_tcb);
-        (void)psx_restore_context_from_tcb(cpu, current_tcb);
-    }
-    cpu->pc = 0;
-    return 1;
-}
-
 static int psx_change_thread(CPUState* cpu, uint32_t target_tcb)
 {
-#ifdef _WIN32
+    /* One scheduler on every platform now: host fibers (Win32 Fibers on
+     * Windows, ucontext on POSIX). The earlier setjmp/longjmp fallback was
+     * removed — it ran target threads nested on the caller's stack, which
+     * couldn't resume an arbitrary suspended thread (the BIOS CD-boot
+     * WaitEvent handoff hung on it). */
     return psx_change_thread_fiber(cpu, target_tcb);
-#else
-    return psx_change_thread_setjmp(cpu, target_tcb);
-#endif
 }
 
 void psx_syscall(CPUState* cpu, uint32_t code) {


### PR DESCRIPTION
Makes the recompiler and runtime build and run natively on **macOS (Apple Silicon & Intel)** and **Linux**, alongside Windows. The recompiled BIOS boots to the PlayStation logo, and (via the consuming game repo) Tomba! boots into gameplay with working memory-card save/load — previously a Windows-only path.

## Core change — the BIOS thread scheduler
The BIOS manages its own threads (TCBs) and switches cooperatively; the runtime mirrors each with a host fiber so a suspended thread keeps its own native stack. The CD-boot handoff depends on this: a thread issues a CD command, `WaitEvent`-blocks, and the scheduler must resume a *different* thread's suspended stack.

- **`runtime/src/psx_fiber.{h,c}` (new)** — one cooperative-fiber API: Win32 Fibers on Windows (identical behavior), `ucontext` (`makecontext`/`swapcontext`) on POSIX, with a `GetCurrentFiber` analog (`psx_fiber_current`).
- **`traps.c`** — the BIOS thread switcher uses `psx_fiber_*` on every platform. The old non-Windows **setjmp/longjmp fallback is removed**: it ran target threads *nested* on the caller's C stack, so it couldn't resume an arbitrary suspended thread — which hung the BIOS CD-boot `WaitEvent` handoff (Tomba froze on the PS logo). Real per-thread stacks fix it.
- **`interrupts.c`** — the exception-deferral path (`g_exception_owner_fiber`, `deferred_exception_longjmp`) is now fiber-based on all platforms via the same abstraction instead of `#ifdef _WIN32`.

## Cross-platform build fixes
- **`recompiler/CMakeLists.txt`** — vendored **fmt 9.1.0** force-enables `consteval` on Apple clang (its `__cpp_consteval` clause overrides its own Apple-exclusion), which clang 21 then rejects; force `FMT_CONSTEVAL` empty on non-MSVC.
- **`runtime.cmake`** — build `psx_fiber.c`; add pkg-config's `SDL2_LIBRARY_DIRS` so `-lSDL2` resolves outside default paths (Homebrew `/opt/homebrew/lib`).
- **`crash_trace.c`** — `#include <stdarg.h>` (not pulled in transitively off Windows).
- **`main.cpp`** — the forced `opengl` render-driver hint (a Windows-GDI-freeze workaround) is now Windows-only so macOS uses Metal; create the renderer with `PRESENTVSYNC`; `SDL_RenderSetLogicalSize(640,480)` so fullscreen letterboxes; add an **F11 / Alt+Enter / Cmd+F** fullscreen toggle.

## Verification
- `SCPH1001.BIN` BIOS boots to the Sony/PlayStation logo on Apple Silicon (discless `psx-runtime`).
- Tomba! (SCUS-94236) boots into gameplay; **memory-card saves persist across relaunches** (confirmed on-device).
- Gamepad (`SDL_GameController`) was already cross-platform — unchanged.

Paired with mstan/TombaRecomp (docs, EXE-extract helper, pin bump). Merge this first; the game repo bumps `psxrecomp-v4.pin` to the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)