### PR TITLE
Release build: v4 rename, release/debug split, resizable window, fiber fix

### DIFF
--- a/recompiler/src/main_bios.cpp
+++ b/recompiler/src/main_bios.cpp
@@ -1,4 +1,4 @@
-// main_bios.cpp
+﻿// main_bios.cpp
 // ----------------------------------------------------------------------------
 // Phase 1a entry point: psxrecomp-bios.
 //
@@ -443,7 +443,7 @@ std::string make_function_manifest_json(const PSXRecompV4::DiscoveryResult& dr,
                                         const std::string& bios_sha256) {
     std::ostringstream os;
     os << "{\n";
-    os << "  \"schema\": \"psxrecomp-v4 phase1c function_manifest v1\",\n";
+    os << "  \"schema\": \"psxrecomp phase1c function_manifest v1\",\n";
     os << fmt::format("  \"bios_sha256\": \"{}\",\n", bios_sha256);
     os << fmt::format("  \"total_functions\": {},\n", dr.total_functions);
     os << fmt::format("  \"total_instructions\": {},\n", dr.total_instructions);
@@ -477,7 +477,7 @@ std::string make_function_manifest_json(const PSXRecompV4::DiscoveryResult& dr,
 std::string make_function_edges_json(const PSXRecompV4::DiscoveryResult& dr) {
     std::ostringstream os;
     os << "{\n";
-    os << "  \"schema\": \"psxrecomp-v4 phase1c function_edges v1\",\n";
+    os << "  \"schema\": \"psxrecomp phase1c function_edges v1\",\n";
     os << fmt::format("  \"total_edges\": {},\n", dr.total_edges);
     os << "  \"edges\": [\n";
 
@@ -500,7 +500,7 @@ std::string make_discovery_log_json(const PSXRecompV4::DiscoveryResult& dr,
                                     const std::vector<PSXRecompV4::Seed>& seeds) {
     std::ostringstream os;
     os << "{\n";
-    os << "  \"schema\": \"psxrecomp-v4 phase1c discovery_run v1\",\n";
+    os << "  \"schema\": \"psxrecomp phase1c discovery_run v1\",\n";
     os << "  \"seeds\": [\n";
     for (size_t i = 0; i < seeds.size(); ++i) {
         os << fmt::format("    {{\"address\": \"0x{:08X}\", \"label\": \"{}\"}}",
@@ -559,7 +559,7 @@ std::string make_discovery_log_json(const PSXRecompV4::DiscoveryResult& dr,
 std::string make_indirect_jumps_json(const PSXRecompV4::DiscoveryResult& dr) {
     std::ostringstream os;
     os << "{\n";
-    os << "  \"schema\": \"psxrecomp-v4 phase1d indirect_jumps v1\",\n";
+    os << "  \"schema\": \"psxrecomp phase1d indirect_jumps v1\",\n";
     os << fmt::format("  \"total_sites\": {},\n", dr.indirect_jumps.size());
     os << "  \"sites\": [\n";
 
@@ -600,7 +600,7 @@ std::string make_indirect_jump_classes_json(const PSXRecompV4::DiscoveryResult& 
 
     std::ostringstream os;
     os << "{\n";
-    os << "  \"schema\": \"psxrecomp-v4 phase1d indirect_jump_classes v1\",\n";
+    os << "  \"schema\": \"psxrecomp phase1d indirect_jump_classes v1\",\n";
     os << fmt::format("  \"total_sites\": {},\n", dr.indirect_jumps.size());
     os << "  \"classes\": {\n";
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+﻿cmake_minimum_required(VERSION 3.20)
 project(psxrecomp-runtime C CXX)
 
 set(CMAKE_C_STANDARD 99)
@@ -22,21 +22,21 @@ endif()
 
 # ---- Native/oracle runtime targets ----
 
-set(PSXRECOMP_V4_ROOT "${CMAKE_SOURCE_DIR}/..")
+set(PSXRECOMP_ROOT "${CMAKE_SOURCE_DIR}/..")
 include("${CMAKE_SOURCE_DIR}/runtime.cmake")
 
-psxrecomp_v4_add_runtime_target(psx-runtime
+psxrecomp_add_runtime_target(psx-runtime
     DEBUG_PORT 4370
-    WINDOW_TITLE "psxrecomp-v4 - BIOS"
-    DEFAULT_BIOS_PATH "${PSXRECOMP_V4_ROOT}/bios/SCPH1001.BIN"
+    WINDOW_TITLE "psxrecomp - BIOS"
+    DEFAULT_BIOS_PATH "${PSXRECOMP_ROOT}/bios/SCPH1001.BIN"
 )
 
 if(NOT MSVC)
-    psxrecomp_v4_add_runtime_target(psx-oracle
+    psxrecomp_add_runtime_target(psx-oracle
         ORACLE
         DEBUG_PORT 4371
-        WINDOW_TITLE "psxrecomp-v4 - Oracle"
-        DEFAULT_BIOS_PATH "${PSXRECOMP_V4_ROOT}/bios/SCPH1001.BIN"
+        WINDOW_TITLE "psxrecomp - Oracle"
+        DEFAULT_BIOS_PATH "${PSXRECOMP_ROOT}/bios/SCPH1001.BIN"
     )
 endif()
 

--- a/runtime/include/beetle_history.h
+++ b/runtime/include/beetle_history.h
@@ -1,4 +1,4 @@
-/* beetle_history.h — psx-beetle per-frame snapshot ring.
+﻿/* beetle_history.h — psx-beetle per-frame snapshot ring.
  *
  * Mirrors runtime/src/debug_server.c's PSXFrameRecord history so beetle
  * exposes the SAME time-series surface as psx-runtime: history,
@@ -13,8 +13,8 @@
  * psx_dispatch() call gates) are left zero and explicitly documented
  * so consumers see real-vs-stub at a glance.
  */
-#ifndef PSXRECOMP_V4_BEETLE_HISTORY_H
-#define PSXRECOMP_V4_BEETLE_HISTORY_H
+#ifndef PSXRECOMP_BEETLE_HISTORY_H
+#define PSXRECOMP_BEETLE_HISTORY_H
 
 #include <stdint.h>
 
@@ -85,4 +85,4 @@ int beetle_history_get_snapshot(int slot, uint32_t *out_addr, int *out_active);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_BEETLE_HISTORY_H */
+#endif /* PSXRECOMP_BEETLE_HISTORY_H */

--- a/runtime/include/card_data_writes.h
+++ b/runtime/include/card_data_writes.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * card_data_writes.h — always-on capture of where the BIOS stores
  * incoming SIO data bytes during memory-card READ_DATA.
  *
@@ -19,8 +19,8 @@
  * read audit, this gives ~32*128=4096 byte writes — enough to see
  * the full destination buffer for several consecutive reads.
  */
-#ifndef PSXRECOMP_V4_CARD_DATA_WRITES_H
-#define PSXRECOMP_V4_CARD_DATA_WRITES_H
+#ifndef PSXRECOMP_CARD_DATA_WRITES_H
+#define PSXRECOMP_CARD_DATA_WRITES_H
 
 #include <stdint.h>
 
@@ -67,4 +67,4 @@ void card_data_writes_reset(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_CARD_DATA_WRITES_H */
+#endif /* PSXRECOMP_CARD_DATA_WRITES_H */

--- a/runtime/include/card_read_summary.h
+++ b/runtime/include/card_read_summary.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * card_read_summary.h — non-evicting evidence ring for the first 32
  * completed memory-card reads.
  *
@@ -12,8 +12,8 @@
  * caller function. The destination RAM pointer is filled in later
  * by the chain-handler trace (Phase 3).
  */
-#ifndef PSXRECOMP_V4_CARD_READ_SUMMARY_H
-#define PSXRECOMP_V4_CARD_READ_SUMMARY_H
+#ifndef PSXRECOMP_CARD_READ_SUMMARY_H
+#define PSXRECOMP_CARD_READ_SUMMARY_H
 
 #include <stdint.h>
 
@@ -58,4 +58,4 @@ void card_read_summary_set_dest(uint32_t dest_addr);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_CARD_READ_SUMMARY_H */
+#endif /* PSXRECOMP_CARD_READ_SUMMARY_H */

--- a/runtime/include/cdrom.h
+++ b/runtime/include/cdrom.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_CDROM_H
-#define PSXRECOMP_V4_CDROM_H
+﻿#ifndef PSXRECOMP_CDROM_H
+#define PSXRECOMP_CDROM_H
 
 #include <stdint.h>
 
@@ -96,4 +96,4 @@ void cdrom_debug_clear_trace(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_CDROM_H */
+#endif /* PSXRECOMP_CDROM_H */

--- a/runtime/include/cpu_state.h
+++ b/runtime/include/cpu_state.h
@@ -1,4 +1,4 @@
-/* ============================================================================
+﻿/* ============================================================================
  * cpu_state.h  —  Phase 2 runtime version
  * ----------------------------------------------------------------------------
  * This is the RUNTIME version of the CPUState header. It has the same struct
@@ -9,8 +9,8 @@
  * "cpu_state.h" and the build uses -I runtime/include so they find this file.
  * ========================================================================== */
 
-#ifndef PSXRECOMP_V4_CPU_STATE_H
-#define PSXRECOMP_V4_CPU_STATE_H
+#ifndef PSXRECOMP_CPU_STATE_H
+#define PSXRECOMP_CPU_STATE_H
 
 #include <stdint.h>
 
@@ -59,4 +59,4 @@ extern void     gte_write_ctrl(CPUState* cpu, uint8_t reg, uint32_t val);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_CPU_STATE_H */
+#endif /* PSXRECOMP_CPU_STATE_H */

--- a/runtime/include/crash_trace.h
+++ b/runtime/include/crash_trace.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_CRASH_TRACE_H
-#define PSXRECOMP_V4_CRASH_TRACE_H
+﻿#ifndef PSXRECOMP_CRASH_TRACE_H
+#define PSXRECOMP_CRASH_TRACE_H
 
 #include <stdint.h>
 
@@ -20,4 +20,4 @@ void psx_crash_trace_dump(const char *reason, void *seh_info);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_CRASH_TRACE_H */
+#endif /* PSXRECOMP_CRASH_TRACE_H */

--- a/runtime/include/debug_server.h
+++ b/runtime/include/debug_server.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * debug_server.h -- TCP debug server for PSX recomp v4
  *
  * Non-blocking TCP server on localhost (default port 4370).
@@ -8,8 +8,8 @@
  * Same public API names as nesrecomp/snesrecomp debug servers
  * so TCP.md and DEBUG.md documentation is reusable across projects.
  */
-#ifndef PSXRECOMP_V4_DEBUG_SERVER_H
-#define PSXRECOMP_V4_DEBUG_SERVER_H
+#ifndef PSXRECOMP_DEBUG_SERVER_H
+#define PSXRECOMP_DEBUG_SERVER_H
 
 #include <stdint.h>
 #include <stdio.h>
@@ -204,4 +204,4 @@ void debug_server_freeze_dump_dirty_block_json(FILE *f, uint32_t max_count);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_DEBUG_SERVER_H */
+#endif /* PSXRECOMP_DEBUG_SERVER_H */

--- a/runtime/include/dirty_ram_interp.h
+++ b/runtime/include/dirty_ram_interp.h
@@ -1,4 +1,4 @@
-/* dirty_ram_interp.h — interpret-on-dispatch for install-at-runtime RAM.
+﻿/* dirty_ram_interp.h — interpret-on-dispatch for install-at-runtime RAM.
  *
  * See CLAUDE.md Rule 18 and docs/dynamic_handler_install.md for the full
  * rationale.  The PS1 BIOS dynamically writes 4-instruction dispatch stubs
@@ -12,8 +12,8 @@
  * RAM.  See docs/dynamic_handler_install.md for the inline note about a
  * potential future migration to runtime JIT (Option B).
  */
-#ifndef PSXRECOMP_V4_DIRTY_RAM_INTERP_H
-#define PSXRECOMP_V4_DIRTY_RAM_INTERP_H
+#ifndef PSXRECOMP_DIRTY_RAM_INTERP_H
+#define PSXRECOMP_DIRTY_RAM_INTERP_H
 
 #include <stdint.h>
 #include "cpu_state.h"
@@ -150,4 +150,4 @@ extern uint64_t             g_dirty_ram_insn_log_seq;
 }
 #endif
 
-#endif /* PSXRECOMP_V4_DIRTY_RAM_INTERP_H */
+#endif /* PSXRECOMP_DIRTY_RAM_INTERP_H */

--- a/runtime/include/dma.h
+++ b/runtime/include/dma.h
@@ -1,4 +1,4 @@
-/* dma.h — PS1 DMA controller simulation (Phase 3).
+﻿/* dma.h — PS1 DMA controller simulation (Phase 3).
  *
  * 7 DMA channels:
  *   Ch0: MDEC in       0x1F801080
@@ -14,8 +14,8 @@
  *   DICR: 0x1F8010F4   (DMA interrupt control)
  */
 
-#ifndef PSXRECOMP_V4_DMA_H
-#define PSXRECOMP_V4_DMA_H
+#ifndef PSXRECOMP_DMA_H
+#define PSXRECOMP_DMA_H
 
 #include <stdint.h>
 
@@ -57,4 +57,4 @@ void dma_debug_clear_trace(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_DMA_H */
+#endif /* PSXRECOMP_DMA_H */

--- a/runtime/include/fntrace.h
+++ b/runtime/include/fntrace.h
@@ -1,4 +1,4 @@
-/* fntrace.h — always-on call ring for recomp psx_dispatch.
+﻿/* fntrace.h — always-on call ring for recomp psx_dispatch.
  *
  * Records every entry into psx_dispatch with the caller's argument
  * registers and return address. Mirrors beetle_libretro.cpp's fntrace
@@ -17,8 +17,8 @@
  * dirty_ram_block_log overlaps with the dirty-RAM subset; this ring is
  * the superset.
  */
-#ifndef PSXRECOMP_V4_FNTRACE_H
-#define PSXRECOMP_V4_FNTRACE_H
+#ifndef PSXRECOMP_FNTRACE_H
+#define PSXRECOMP_FNTRACE_H
 
 #include <stdint.h>
 #include "cpu_state.h"
@@ -65,4 +65,4 @@ void fntrace_clear(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_FNTRACE_H */
+#endif /* PSXRECOMP_FNTRACE_H */

--- a/runtime/include/freeze_heartbeat.h
+++ b/runtime/include/freeze_heartbeat.h
@@ -1,4 +1,4 @@
-/* freeze_heartbeat.h — observability infrastructure.
+﻿/* freeze_heartbeat.h — observability infrastructure.
  *
  * Starts a background thread that snapshots runtime state to
  * `psx_freeze_heartbeat.json` every ~100 ms. Survives main-thread
@@ -12,8 +12,8 @@
  * the runtime was in just before it stalled.
  */
 
-#ifndef PSXRECOMP_V4_FREEZE_HEARTBEAT_H
-#define PSXRECOMP_V4_FREEZE_HEARTBEAT_H
+#ifndef PSXRECOMP_FREEZE_HEARTBEAT_H
+#define PSXRECOMP_FREEZE_HEARTBEAT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,4 +29,4 @@ void freeze_heartbeat_start(const char *backend_label);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_FREEZE_HEARTBEAT_H */
+#endif /* PSXRECOMP_FREEZE_HEARTBEAT_H */

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -1,11 +1,11 @@
-/* gpu.h — PS1 GPU hardware simulation (Phase 3).
+﻿/* gpu.h — PS1 GPU hardware simulation (Phase 3).
  *
  * Implements GPUSTAT, GP0, GP1, and 1024x512 16-bit VRAM.
  * No rendering to screen — just correct hardware state transitions.
  */
 
-#ifndef PSXRECOMP_V4_GPU_H
-#define PSXRECOMP_V4_GPU_H
+#ifndef PSXRECOMP_GPU_H
+#define PSXRECOMP_GPU_H
 
 #include <stdint.h>
 
@@ -80,4 +80,4 @@ void gpu_set_vblank_callback(gpu_vblank_cb cb);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_GPU_H */
+#endif /* PSXRECOMP_GPU_H */

--- a/runtime/include/interrupts.h
+++ b/runtime/include/interrupts.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_INTERRUPTS_H
-#define PSXRECOMP_V4_INTERRUPTS_H
+﻿#ifndef PSXRECOMP_INTERRUPTS_H
+#define PSXRECOMP_INTERRUPTS_H
 
 #include <stdint.h>
 
@@ -71,4 +71,4 @@ void psx_restore_state_escape(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_INTERRUPTS_H */
+#endif /* PSXRECOMP_INTERRUPTS_H */

--- a/runtime/include/mdec.h
+++ b/runtime/include/mdec.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_MDEC_H
-#define PSXRECOMP_V4_MDEC_H
+﻿#ifndef PSXRECOMP_MDEC_H
+#define PSXRECOMP_MDEC_H
 
 #include <stdint.h>
 
@@ -70,4 +70,4 @@ void mdec_debug_dma_out_end(uint32_t addr, uint32_t words);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_MDEC_H */
+#endif /* PSXRECOMP_MDEC_H */

--- a/runtime/include/memcard.h
+++ b/runtime/include/memcard.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_MEMCARD_H
-#define PSXRECOMP_V4_MEMCARD_H
+﻿#ifndef PSXRECOMP_MEMCARD_H
+#define PSXRECOMP_MEMCARD_H
 
 #include <stdint.h>
 
@@ -41,4 +41,4 @@ int memcard_debug_read_buffer(int card, uint32_t offset, uint32_t len,
 }
 #endif
 
-#endif /* PSXRECOMP_V4_MEMCARD_H */
+#endif /* PSXRECOMP_MEMCARD_H */

--- a/runtime/include/psx_cycles.h
+++ b/runtime/include/psx_cycles.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_PSX_CYCLES_H
-#define PSXRECOMP_V4_PSX_CYCLES_H
+﻿#ifndef PSXRECOMP_PSX_CYCLES_H
+#define PSXRECOMP_PSX_CYCLES_H
 
 #include <stdint.h>
 
@@ -26,4 +26,4 @@ uint64_t psx_get_cycle_count(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_PSX_CYCLES_H */
+#endif /* PSXRECOMP_PSX_CYCLES_H */

--- a/runtime/include/psx_interpreter.h
+++ b/runtime/include/psx_interpreter.h
@@ -1,4 +1,4 @@
-/* psx_interpreter.h — R3000A interpreter for oracle builds.
+﻿/* psx_interpreter.h — R3000A interpreter for oracle builds.
  *
  * Oracle-only: provides a cycle-accurate reference implementation
  * of the PSX CPU. Shares the same CPUState and memory bus as the
@@ -9,8 +9,8 @@
  * source tree, gated by PSX_ORACLE_BUILD.
  */
 
-#ifndef PSXRECOMP_V4_PSX_INTERPRETER_H
-#define PSXRECOMP_V4_PSX_INTERPRETER_H
+#ifndef PSXRECOMP_PSX_INTERPRETER_H
+#define PSXRECOMP_PSX_INTERPRETER_H
 
 #include "cpu_state.h"
 #include <stdint.h>
@@ -56,4 +56,4 @@ const InterpTraceEntry* interp_trace_get(uint32_t ring_idx);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_PSX_INTERPRETER_H */
+#endif /* PSXRECOMP_PSX_INTERPRETER_H */

--- a/runtime/include/psx_runtime.h
+++ b/runtime/include/psx_runtime.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_PSX_RUNTIME_H
-#define PSXRECOMP_V4_PSX_RUNTIME_H
+﻿#ifndef PSXRECOMP_PSX_RUNTIME_H
+#define PSXRECOMP_PSX_RUNTIME_H
 
 #include "cpu_state.h"
 #include "interrupts.h"
@@ -17,4 +17,4 @@ static inline void call_by_address(CPUState* cpu, uint32_t addr) {
 }
 #endif
 
-#endif /* PSXRECOMP_V4_PSX_RUNTIME_H */
+#endif /* PSXRECOMP_PSX_RUNTIME_H */

--- a/runtime/include/sio.h
+++ b/runtime/include/sio.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_SIO_H
-#define PSXRECOMP_V4_SIO_H
+﻿#ifndef PSXRECOMP_SIO_H
+#define PSXRECOMP_SIO_H
 
 #include <stdint.h>
 
@@ -189,4 +189,4 @@ uint32_t sio_get_irq_ring(const SioIrqEntry **buf_out, int *write_idx_out);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_SIO_H */
+#endif /* PSXRECOMP_SIO_H */

--- a/runtime/include/spu.h
+++ b/runtime/include/spu.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_SPU_H
-#define PSXRECOMP_V4_SPU_H
+﻿#ifndef PSXRECOMP_SPU_H
+#define PSXRECOMP_SPU_H
 
 #include <stdint.h>
 
@@ -112,4 +112,4 @@ const uint8_t* spu_get_ram(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_SPU_H */
+#endif /* PSXRECOMP_SPU_H */

--- a/runtime/include/starvation_ring.h
+++ b/runtime/include/starvation_ring.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * starvation_ring.h — Always-on diagnostic ring for capturing SIO/MMIO
  * state immediately before a TCP-starvation hang.
  *
@@ -10,8 +10,8 @@
  *
  * NOT for permanent use. Disabled by setting STARVATION_RING_ENABLED=0.
  */
-#ifndef PSXRECOMP_V4_STARVATION_RING_H
-#define PSXRECOMP_V4_STARVATION_RING_H
+#ifndef PSXRECOMP_STARVATION_RING_H
+#define PSXRECOMP_STARVATION_RING_H
 
 #include <stdint.h>
 
@@ -105,4 +105,4 @@ void starvation_ring_pc_sample(void);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_STARVATION_RING_H */
+#endif /* PSXRECOMP_STARVATION_RING_H */

--- a/runtime/include/timers.h
+++ b/runtime/include/timers.h
@@ -1,5 +1,5 @@
-#ifndef PSXRECOMP_V4_TIMERS_H
-#define PSXRECOMP_V4_TIMERS_H
+﻿#ifndef PSXRECOMP_TIMERS_H
+#define PSXRECOMP_TIMERS_H
 
 #include <stdint.h>
 
@@ -26,4 +26,4 @@ void timers_tick(int cycles);
 }
 #endif
 
-#endif /* PSXRECOMP_V4_TIMERS_H */
+#endif /* PSXRECOMP_TIMERS_H */

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1,11 +1,11 @@
-# Shared psxrecomp-v4 runtime CMake helpers.
+﻿# Shared psxrecomp runtime CMake helpers.
 #
 # Include this from either the framework runtime build or a sibling game
-# project. Call psxrecomp_v4_add_runtime_target() after SDL2 detection has
+# project. Call psxrecomp_add_runtime_target() after SDL2 detection has
 # populated SDL2_INCLUDE_DIRS and SDL2_LIBRARIES.
 
-if(NOT DEFINED PSXRECOMP_V4_ROOT)
-    get_filename_component(PSXRECOMP_V4_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+if(NOT DEFINED PSXRECOMP_ROOT)
+    get_filename_component(PSXRECOMP_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 endif()
 
 # Production build flag: -DPSX_DEBUG_TOOLS=OFF disables the TCP debug
@@ -18,7 +18,7 @@ option(PSX_DEBUG_TOOLS "Build with TCP debug server + heartbeat + per-block reco
 
 if(NOT SDL2_INCLUDE_DIRS OR NOT SDL2_LIBRARIES)
     if(MSVC)
-        file(GLOB SDL2_MSVC_DIR "${PSXRECOMP_V4_ROOT}/../sdl2-msvc/SDL2-*")
+        file(GLOB SDL2_MSVC_DIR "${PSXRECOMP_ROOT}/../sdl2-msvc/SDL2-*")
         if(SDL2_MSVC_DIR)
             set(SDL2_INCLUDE_DIRS "${SDL2_MSVC_DIR}/include")
             set(SDL2_LIBRARIES "${SDL2_MSVC_DIR}/lib/x64/SDL2.lib")
@@ -40,50 +40,50 @@ if(NOT SDL2_INCLUDE_DIRS OR NOT SDL2_LIBRARIES)
     endif()
 endif()
 
-set(PSXRECOMP_V4_RUNTIME_SOURCES
-    ${PSXRECOMP_V4_ROOT}/runtime/src/main.cpp
-    ${PSXRECOMP_V4_ROOT}/runtime/src/memory.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/gpu.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/gpu_sw_renderer.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/dma.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/mdec.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/timers.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/interrupts.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/psx_fiber.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/sio.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/memcard.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/debug_server.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/dirty_ram_interp.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/fntrace.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/traps.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/crash_trace.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/freeze_heartbeat.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/gte.cpp
-    ${PSXRECOMP_V4_ROOT}/runtime/src/crc32.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/cdrom.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/spu.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/iso_reader.cpp
-    ${PSXRECOMP_V4_ROOT}/runtime/src/iso_reader_c.cpp
-    ${PSXRECOMP_V4_ROOT}/runtime/src/psx_cycles.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/starvation_ring.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/card_read_summary.c
-    ${PSXRECOMP_V4_ROOT}/runtime/src/card_data_writes.c
-    ${PSXRECOMP_V4_ROOT}/recompiler/src/config_loader.cpp
+set(PSXRECOMP_RUNTIME_SOURCES
+    ${PSXRECOMP_ROOT}/runtime/src/main.cpp
+    ${PSXRECOMP_ROOT}/runtime/src/memory.c
+    ${PSXRECOMP_ROOT}/runtime/src/gpu.c
+    ${PSXRECOMP_ROOT}/runtime/src/gpu_sw_renderer.c
+    ${PSXRECOMP_ROOT}/runtime/src/dma.c
+    ${PSXRECOMP_ROOT}/runtime/src/mdec.c
+    ${PSXRECOMP_ROOT}/runtime/src/timers.c
+    ${PSXRECOMP_ROOT}/runtime/src/interrupts.c
+    ${PSXRECOMP_ROOT}/runtime/src/psx_fiber.c
+    ${PSXRECOMP_ROOT}/runtime/src/sio.c
+    ${PSXRECOMP_ROOT}/runtime/src/memcard.c
+    ${PSXRECOMP_ROOT}/runtime/src/debug_server.c
+    ${PSXRECOMP_ROOT}/runtime/src/dirty_ram_interp.c
+    ${PSXRECOMP_ROOT}/runtime/src/fntrace.c
+    ${PSXRECOMP_ROOT}/runtime/src/traps.c
+    ${PSXRECOMP_ROOT}/runtime/src/crash_trace.c
+    ${PSXRECOMP_ROOT}/runtime/src/freeze_heartbeat.c
+    ${PSXRECOMP_ROOT}/runtime/src/gte.cpp
+    ${PSXRECOMP_ROOT}/runtime/src/crc32.c
+    ${PSXRECOMP_ROOT}/runtime/src/cdrom.c
+    ${PSXRECOMP_ROOT}/runtime/src/spu.c
+    ${PSXRECOMP_ROOT}/runtime/src/iso_reader.cpp
+    ${PSXRECOMP_ROOT}/runtime/src/iso_reader_c.cpp
+    ${PSXRECOMP_ROOT}/runtime/src/psx_cycles.c
+    ${PSXRECOMP_ROOT}/runtime/src/starvation_ring.c
+    ${PSXRECOMP_ROOT}/runtime/src/card_read_summary.c
+    ${PSXRECOMP_ROOT}/runtime/src/card_data_writes.c
+    ${PSXRECOMP_ROOT}/recompiler/src/config_loader.cpp
 )
 
-set(PSXRECOMP_V4_RUNTIME_INCLUDE_DIRS
-    ${PSXRECOMP_V4_ROOT}/runtime/include
-    ${PSXRECOMP_V4_ROOT}/recompiler/src
-    ${PSXRECOMP_V4_ROOT}/recompiler/lib/fmt/include
-    ${PSXRECOMP_V4_ROOT}/recompiler/lib/toml11
+set(PSXRECOMP_RUNTIME_INCLUDE_DIRS
+    ${PSXRECOMP_ROOT}/runtime/include
+    ${PSXRECOMP_ROOT}/recompiler/src
+    ${PSXRECOMP_ROOT}/recompiler/lib/fmt/include
+    ${PSXRECOMP_ROOT}/recompiler/lib/toml11
 )
 
-set(PSXRECOMP_V4_BIOS_GENERATED
-    ${PSXRECOMP_V4_ROOT}/generated/SCPH1001_full.c
-    ${PSXRECOMP_V4_ROOT}/generated/SCPH1001_dispatch.c
+set(PSXRECOMP_BIOS_GENERATED
+    ${PSXRECOMP_ROOT}/generated/SCPH1001_full.c
+    ${PSXRECOMP_ROOT}/generated/SCPH1001_dispatch.c
 )
 
-function(psxrecomp_v4_add_runtime_target target)
+function(psxrecomp_add_runtime_target target)
     set(options ORACLE)
     set(oneValueArgs
         GAME_GENERATED_FULL_C
@@ -106,13 +106,13 @@ function(psxrecomp_v4_add_runtime_target target)
         set(PSXRT_WINDOW_TITLE "${target}")
     endif()
     if(NOT PSXRT_DEFAULT_BIOS_PATH)
-        set(PSXRT_DEFAULT_BIOS_PATH "${PSXRECOMP_V4_ROOT}/bios/SCPH1001.BIN")
+        set(PSXRT_DEFAULT_BIOS_PATH "${PSXRECOMP_ROOT}/bios/SCPH1001.BIN")
     endif()
     if(NOT DEFINED PSXRT_DEFAULT_GAME_CONFIG_PATH)
         set(PSXRT_DEFAULT_GAME_CONFIG_PATH "")
     endif()
 
-    set(generated_sources ${PSXRECOMP_V4_BIOS_GENERATED})
+    set(generated_sources ${PSXRECOMP_BIOS_GENERATED})
     if(PSXRT_GAME_GENERATED_FULL_C)
         set_source_files_properties("${PSXRT_GAME_GENERATED_FULL_C}" PROPERTIES GENERATED TRUE)
         list(APPEND generated_sources "${PSXRT_GAME_GENERATED_FULL_C}")
@@ -125,20 +125,20 @@ function(psxrecomp_v4_add_runtime_target target)
     endif()
 
     if(PSXRT_ORACLE)
-        set(mode_source ${PSXRECOMP_V4_ROOT}/runtime/src/psx_interpreter.c)
+        set(mode_source ${PSXRECOMP_ROOT}/runtime/src/psx_interpreter.c)
     else()
-        set(mode_source ${PSXRECOMP_V4_ROOT}/runtime/src/stub_interpreter.c)
+        set(mode_source ${PSXRECOMP_ROOT}/runtime/src/stub_interpreter.c)
     endif()
 
     add_executable(${target}
-        ${PSXRECOMP_V4_RUNTIME_SOURCES}
+        ${PSXRECOMP_RUNTIME_SOURCES}
         ${mode_source}
         ${generated_sources}
         ${PSXRT_EXTRAS_SOURCES}
     )
 
     target_include_directories(${target} PRIVATE
-        ${PSXRECOMP_V4_RUNTIME_INCLUDE_DIRS}
+        ${PSXRECOMP_RUNTIME_INCLUDE_DIRS}
         ${SDL2_INCLUDE_DIRS}
     )
     # pkg-config reports SDL2_LIBRARIES as a bare name (e.g. "SDL2" -> -lSDL2);

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -8,13 +8,16 @@ if(NOT DEFINED PSXRECOMP_ROOT)
     get_filename_component(PSXRECOMP_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 endif()
 
-# Production build flag: -DPSX_DEBUG_TOOLS=OFF disables the TCP debug
-# server, the freeze heartbeat thread, and the hot-path log functions
-# (call_entry / sio_write / probe / restore_event / thread_event) that
-# the recompiled C invokes on every block. Use to test whether the
-# debug infrastructure itself contributes to freezes, or to ship a
-# lean production binary. Visible to all targets including psx-beetle.
-option(PSX_DEBUG_TOOLS "Build with TCP debug server + heartbeat + per-block recording" ON)
+# PSX_DEBUG_TOOLS: TCP debug server + heartbeat + per-block recording.
+# Defaults ON for Debug/RelWithDebInfo, OFF for Release/MinSizeRel so
+# a plain cmake -DCMAKE_BUILD_TYPE=Release gives a lean production binary
+# with no TCP server and no debug console. Override explicitly with
+# -DPSX_DEBUG_TOOLS=ON/OFF to force either way regardless of build type.
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    option(PSX_DEBUG_TOOLS "Build with TCP debug server + heartbeat + per-block recording" OFF)
+else()
+    option(PSX_DEBUG_TOOLS "Build with TCP debug server + heartbeat + per-block recording" ON)
+endif()
 
 if(NOT SDL2_INCLUDE_DIRS OR NOT SDL2_LIBRARIES)
     if(MSVC)
@@ -182,8 +185,15 @@ function(psxrecomp_add_runtime_target target)
 
     if(MINGW)
         target_link_options(${target} PRIVATE -Wl,--stack,67108864)
+        # No console window in Release MinGW builds.
+        target_link_options(${target} PRIVATE $<$<CONFIG:Release>:-mwindows>)
     elseif(MSVC)
         target_compile_options(${target} PRIVATE /GS- /guard:cf-)
         target_link_options(${target} PRIVATE /STACK:67108864,67108864 /GUARD:NO)
+        # No console window in Release MSVC builds. /ENTRY keeps main() as
+        # the entry point (not WinMain) while switching to the Windows subsystem.
+        target_link_options(${target} PRIVATE
+            $<$<CONFIG:Release>:/SUBSYSTEM:WINDOWS>
+            $<$<CONFIG:Release>:/ENTRY:mainCRTStartup>)
     endif()
 endfunction()

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1,4 +1,4 @@
-/* main.cpp — Phase 3 runtime entry point.
+﻿/* main.cpp — Phase 3 runtime entry point.
  *
  * Loads BIOS ROM, initializes CPU state + SDL display, calls into
  * the recompiled reset vector. BIOS drives execution; SDL presents
@@ -46,7 +46,7 @@
 #define PSX_DEFAULT_GAME_CONFIG_PATH ""
 #endif
 #ifndef PSX_WINDOW_TITLE
-#define PSX_WINDOW_TITLE "psxrecomp-v4"
+#define PSX_WINDOW_TITLE "psxrecomp"
 #endif
 #ifndef DEFAULT_DEBUG_PORT
 #error DEFAULT_DEBUG_PORT must be defined by the runtime target.
@@ -186,7 +186,7 @@ static bool pick_runtime_file(const char* title, const char* filter,
 #else
     (void)filter;
     (void)out;
-    std::fprintf(stderr, "psxrecomp-v4: %s requires a command-line path on this platform.\n", title);
+    std::fprintf(stderr, "psxrecomp: %s requires a command-line path on this platform.\n", title);
     return false;
 #endif
 }
@@ -806,7 +806,7 @@ static void open_configured_controller(void) {
             SDL_Joystick* joy = SDL_GameControllerGetJoystick(sdl_controller);
             sdl_controller_instance = joy ? SDL_JoystickInstanceID(joy) : -1;
             const char* name = SDL_GameControllerName(sdl_controller);
-            std::fprintf(stdout, "psxrecomp-v4 runtime: controller %d: %s\n",
+            std::fprintf(stdout, "psxrecomp runtime: controller %d: %s\n",
                          controller_device_index, name ? name : "(unnamed)");
         }
         break;
@@ -1019,7 +1019,7 @@ int main(int argc, char** argv) {
     /* Force line-buffered output so messages appear even if killed. */
     std::setvbuf(stdout, nullptr, _IOLBF, 0);
     std::setvbuf(stderr, nullptr, _IOLBF, 0);
-    std::fprintf(stderr, "psxrecomp-v4: main() entered\n");
+    std::fprintf(stderr, "psxrecomp: main() entered\n");
     std::fflush(stderr);
 
     /* Install crash handlers early so they catch issues during init too.
@@ -1074,10 +1074,10 @@ int main(int argc, char** argv) {
             if (gc.runtime.has_memcard_dir)  memcard_dir   = gc.runtime.memcard_dir;
             if (gc.runtime.has_window_title) window_title  = gc.runtime.window_title;
             if (gc.runtime.has_debug_port)   debug_port    = gc.runtime.debug_port;
-            std::fprintf(stdout, "psxrecomp-v4: loaded game config %s (%s, %s)\n",
+            std::fprintf(stdout, "psxrecomp: loaded game config %s (%s, %s)\n",
                          game_config_path, game_name.c_str(), game_id.c_str());
         } catch (const std::exception& ex) {
-            std::fprintf(stderr, "psxrecomp-v4: failed to load --game %s: %s\n",
+            std::fprintf(stderr, "psxrecomp: failed to load --game %s: %s\n",
                          game_config_path, ex.what());
             return 1;
         }
@@ -1085,13 +1085,13 @@ int main(int argc, char** argv) {
 
     std::filesystem::path resolved_bios = resolve_bios_for_runtime(bios_path, argv[0]);
     if (resolved_bios.empty()) {
-        std::fprintf(stderr, "psxrecomp-v4: no BIOS selected; exiting.\n");
+        std::fprintf(stderr, "psxrecomp: no BIOS selected; exiting.\n");
         return 1;
     }
     if (game_config_path || disc_override_path || !resolved_disc.empty()) {
         resolved_disc = resolve_disc_for_runtime(resolved_disc, disc_override_path, game_id, argv[0]);
         if (game_config_path && resolved_disc.empty()) {
-            std::fprintf(stderr, "psxrecomp-v4: no disc image selected; exiting.\n");
+            std::fprintf(stderr, "psxrecomp: no disc image selected; exiting.\n");
             return 1;
         }
     }
@@ -1104,7 +1104,7 @@ int main(int argc, char** argv) {
     std::string memcard_dir_str  = memcard_dir.string();
     std::string disc_path_str    = resolved_disc.string();
 
-    std::fprintf(stdout, "psxrecomp-v4 runtime: loading BIOS from %s\n", bios_path_str.c_str());
+    std::fprintf(stdout, "psxrecomp runtime: loading BIOS from %s\n", bios_path_str.c_str());
     memory_init(bios_path_str.c_str());
     gpu_init();
     dma_init();
@@ -1243,10 +1243,10 @@ int main(int argc, char** argv) {
     debug_server_set_cpu(&cpu);
 
     /* Execute. */
-    std::fprintf(stdout, "psxrecomp-v4 runtime: executing from PC=0x%08X\n", cpu.pc);
+    std::fprintf(stdout, "psxrecomp runtime: executing from PC=0x%08X\n", cpu.pc);
 
 #if defined(PSX_ORACLE_BUILD)
-    std::fprintf(stdout, "psxrecomp-v4 ORACLE: interpreter mode (port %d)\n", DEFAULT_DEBUG_PORT);
+    std::fprintf(stdout, "psxrecomp ORACLE: interpreter mode (port %d)\n", DEFAULT_DEBUG_PORT);
     interp_init(&cpu);
     interp_trace_enable(1);
 
@@ -1326,7 +1326,7 @@ int main(int argc, char** argv) {
 #endif
 
     /* If we reach here, all execution completed without MMIO abort. */
-    std::fprintf(stdout, "psxrecomp-v4 runtime: execution completed, PC=0x%08X\n", cpu.pc);
+    std::fprintf(stdout, "psxrecomp runtime: execution completed, PC=0x%08X\n", cpu.pc);
 
     shutdown_runtime();
     SDL_DestroyTexture(sdl_texture);

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1154,7 +1154,7 @@ int main(int argc, char** argv) {
         window_title.c_str(),
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
         640, 480,
-        SDL_WINDOW_SHOWN
+        SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
     );
     if (!sdl_window) {
         std::fprintf(stderr, "SDL_CreateWindow failed: %s\n", SDL_GetError());

--- a/runtime/src/psx_fiber.c
+++ b/runtime/src/psx_fiber.c
@@ -10,14 +10,17 @@
 
 psx_fiber_t psx_fiber_convert_thread(void)
 {
-    /* If already a fiber, GetCurrentFiber returns it; otherwise convert.
-     * On a freshly-converted thread GetCurrentFiber == the new fiber. */
-    void* cur = GetCurrentFiber();
-    /* 0 and 0x1E00000000000000 are the documented "not a fiber" sentinels. */
-    if (cur == NULL || cur == (void*)(uintptr_t)0x1E00000000000000ULL) {
-        cur = ConvertThreadToFiber(NULL);
-    }
-    return (psx_fiber_t)cur;
+    /* Attempt the conversion unconditionally and check the error code on
+     * failure. The 0x1E00000000000000 TEB sentinel for "not yet a fiber"
+     * is MSVC-internal and not guaranteed by MinGW's GetCurrentFiber()
+     * implementation — reading it before ConvertThreadToFiber is called
+     * can return an unspecified TEB value that isn't the sentinel, causing
+     * the sentinel check to silently skip ConvertThreadToFiber, leaving
+     * the thread as a non-fiber, and crashing the first SwitchToFiber. */
+    void* fib = ConvertThreadToFiber(NULL);
+    if (!fib && GetLastError() == ERROR_ALREADY_FIBER)
+        fib = GetCurrentFiber();
+    return (psx_fiber_t)fib;
 }
 
 psx_fiber_t psx_fiber_current(void)      { return (psx_fiber_t)GetCurrentFiber(); }

--- a/tools/_options_session/_beetle_diff.py
+++ b/tools/_options_session/_beetle_diff.py
@@ -1,7 +1,7 @@
-"""Diff critical memory addresses between runtime (4470) and beetle (4380)
+﻿"""Diff critical memory addresses between runtime (4470) and beetle (4380)
 to find where Tomba's state machine diverges in OPTIONS-black."""
 import sys, struct
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 def read_word(port, addr):

--- a/tools/_options_session/_decode_b0_callers.py
+++ b/tools/_options_session/_decode_b0_callers.py
@@ -1,7 +1,7 @@
-"""Read MIPS at the B0 call sites to identify what BIOS function each calls.
+﻿"""Read MIPS at the B0 call sites to identify what BIOS function each calls.
 The t1 register holds the B0 function index when calling B0 trampoline."""
 import sys, struct
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 call_sites = [0x800171F8, 0x800170BC, 0x8006825C]

--- a/tools/_options_session/_dump_bios_bytes.py
+++ b/tools/_options_session/_dump_bios_bytes.py
@@ -1,5 +1,5 @@
-import struct, sys
-with open('F:/Projects/psxrecomp-v4/bios/SCPH1001.BIN', 'rb') as f:
+﻿import struct, sys
+with open('F:/Projects/psxrecomp/psxrecomp/bios/SCPH1001.BIN', 'rb') as f:
     data = f.read()
 # Read inputs as pc, length
 start_pc = int(sys.argv[1], 16) if len(sys.argv) > 1 else 0xBFC16060

--- a/tools/_options_session/_dump_ram.py
+++ b/tools/_options_session/_dump_ram.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 addr = int(sys.argv[1], 16)
 size = int(sys.argv[2], 0) if len(sys.argv) > 2 else 0x200

--- a/tools/_options_session/_event_waits.py
+++ b/tools/_options_session/_event_waits.py
@@ -1,6 +1,6 @@
-"""Sample fntrace and identify the event IDs Tomba is polling each frame."""
+﻿"""Sample fntrace and identify the event IDs Tomba is polling each frame."""
 import sys, time, collections, json
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 _dbg.call(4470, "fntrace_arm", target="0xFFFFFFFF", timeout=2)

--- a/tools/_options_session/_fn_what_runs.py
+++ b/tools/_options_session/_fn_what_runs.py
@@ -1,6 +1,6 @@
-"""Arm fntrace, sample, find what Tomba functions actually run during black screen."""
+﻿"""Arm fntrace, sample, find what Tomba functions actually run during black screen."""
 import sys, time, collections, json
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 # Make sure fntrace is armed for the entire Tomba RAM range

--- a/tools/_options_session/_live_loop.py
+++ b/tools/_options_session/_live_loop.py
@@ -1,6 +1,6 @@
-"""Query live runtime's recent activity rings to see what's looping."""
+﻿"""Query live runtime's recent activity rings to see what's looping."""
 import sys, json, collections
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 # Try fntrace_dump first

--- a/tools/_options_session/_read_state.py
+++ b/tools/_options_session/_read_state.py
@@ -1,5 +1,5 @@
-import sys, struct
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys, struct
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 # Read scratchpad ptr at 0x1F8001D4

--- a/tools/_options_session/_read_tomba_fn.py
+++ b/tools/_options_session/_read_tomba_fn.py
@@ -1,5 +1,5 @@
-import sys, struct
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys, struct
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 addr = int(sys.argv[1], 16) if len(sys.argv) > 1 else 0x0005B40C

--- a/tools/_options_session/_read_word.py
+++ b/tools/_options_session/_read_word.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 addr = int(sys.argv[1], 16)
 v = _dbg.read_word(4470, addr)

--- a/tools/_options_session/_search_ec_bytes.py
+++ b/tools/_options_session/_search_ec_bytes.py
@@ -1,7 +1,7 @@
-"""Find where 'EC' bytes (0x45, 0x43) appear in runtime memory but not beetle.
+﻿"""Find where 'EC' bytes (0x45, 0x43) appear in runtime memory but not beetle.
 That tells us if 0x43450000 at 0x8009B3D4 is from a stale buffer/string."""
 import sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 # Scan a wide range of low RAM (0x80010000..0x80100000) for any place where

--- a/tools/_options_session/_snapshot.py
+++ b/tools/_options_session/_snapshot.py
@@ -1,6 +1,6 @@
-"""Compact one-line snapshot of runtime state for diff'ing across nav events."""
+﻿"""Compact one-line snapshot of runtime state for diff'ing across nav events."""
 import sys, json
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 label = sys.argv[1] if len(sys.argv) > 1 else "snap"

--- a/tools/_options_session/_state_diff.py
+++ b/tools/_options_session/_state_diff.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 print(f"{'thing':>40}  {'runtime':>12}  {'beetle':>12}")

--- a/tools/_options_session/_thread_live.py
+++ b/tools/_options_session/_thread_live.py
@@ -1,6 +1,6 @@
-"""Query live thread_trace and see if ChangeTh ping-pong is active now."""
+﻿"""Query live thread_trace and see if ChangeTh ping-pong is active now."""
 import sys, json, collections
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 try:

--- a/tools/_options_session/_watch_display.py
+++ b/tools/_options_session/_watch_display.py
@@ -1,6 +1,6 @@
-"""Sample gpu_state every 500ms for 10 sec and see if display origin moves."""
+﻿"""Sample gpu_state every 500ms for 10 sec and see if display origin moves."""
 import time, json, sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 prev = None

--- a/tools/_options_session/_watch_iec.py
+++ b/tools/_options_session/_watch_iec.py
@@ -1,6 +1,6 @@
-"""Sample SR / IRQ state to check if IEc ever goes back to 1."""
+﻿"""Sample SR / IRQ state to check if IEc ever goes back to 1."""
 import time, sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 print(f"{'i':>3} {'frame':>6} {'sr':>10} {'IEc':>3} {'IEp':>3} {'IEo':>3} "

--- a/tools/_options_session/_watch_state.py
+++ b/tools/_options_session/_watch_state.py
@@ -1,6 +1,6 @@
-"""Sample Tomba's state machine state every 500ms for 15 sec."""
+﻿"""Sample Tomba's state machine state every 500ms for 15 sec."""
 import time, sys
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 prev = None

--- a/tools/_options_session/_wtrace_query.py
+++ b/tools/_options_session/_wtrace_query.py
@@ -1,5 +1,5 @@
-import sys, json, time
-sys.path.insert(0, 'F:/Projects/psxrecomp-v4/tools/_options_session')
+﻿import sys, json, time
+sys.path.insert(0, 'F:/Projects/psxrecomp/psxrecomp/tools/_options_session')
 import _dbg
 
 # wtrace_dump returns ALL captured events for the armed ranges

--- a/tools/_parse_crash.py
+++ b/tools/_parse_crash.py
@@ -1,9 +1,9 @@
-"""Parse psx_last_run_report.json — show: reason, cpu state, last 30
+﻿"""Parse psx_last_run_report.json — show: reason, cpu state, last 30
 dispatch_ring entries, last 5 unknown_dispatch entries, last 30
 dirty_block_log entries. Highlight the relevant ones for the
 0xBFC09790 caller investigation."""
 import json
-with open(r'F:\Projects\psxrecomp-v4\psx_last_run_report.json') as f:
+with open(r'F:\Projects\psxrecomp\psx_last_run_report.json') as f:
     r = json.load(f)
 
 print(f"reason: {r.get('reason')}")

--- a/tools/audit_config.py
+++ b/tools/audit_config.py
@@ -1,7 +1,7 @@
-"""Shared audit-config loader.
+﻿"""Shared audit-config loader.
 
 Reads a TOML config (BIOS or game) into a normalized object that the
-psxrecomp-v4 audit tools can consume. See `bios/SCPH1001.toml` and
+psxrecomp audit tools can consume. See `bios/SCPH1001.toml` and
 `TombaRecomp/game.toml` for the schema this module accepts.
 
 Project root is auto-detected by walking up from the config file until a
@@ -87,9 +87,9 @@ def _find_project_root(config_path: Path) -> Path:
     """Walk up from config_path until we find a root marker.
 
     Markers (any one is sufficient): `.gitignore`, `.git`, `CMakeLists.txt`.
-    `.gitignore` is the most reliable — both psxrecomp-v4 and TombaRecomp
+    `.gitignore` is the most reliable — both psxrecomp and TombaRecomp
     have one at the repo root, while CMakeLists.txt only lives in subdirs
-    of psxrecomp-v4 (recompiler/, runtime/).
+    of psxrecomp (recompiler/, runtime/).
     """
     cur = config_path.parent.resolve()
     for _ in range(8):  # bounded search

--- a/tools/build_instruction_coverage.py
+++ b/tools/build_instruction_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+﻿#!/usr/bin/env python3
 """
 build_instruction_coverage.py
 
@@ -196,7 +196,7 @@ def main():
             })
 
     summary = {
-        "schema": "psxrecomp-v4 phase1b instruction_coverage v1",
+        "schema": "psxrecomp phase1b instruction_coverage v1",
         "inventory_source": "generated/instruction_inventory.json",
         "translator_source": TRANSLATOR_PATH,
         "totals": {

--- a/tools/build_instruction_inventory.py
+++ b/tools/build_instruction_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+﻿#!/usr/bin/env python3
 """
 build_instruction_inventory.py
 
@@ -547,7 +547,7 @@ def main():
 
     synth_walks = [w for w in walks if w.get("kind") == "synthetic_seed"]
     out_doc = {
-        "schema": "psxrecomp-v4 phase1b instruction_inventory v2",
+        "schema": "psxrecomp phase1b instruction_inventory v2",
         "program": "SCPH1001.BIN",
         "image_base": "0xbfc00000",
         "image_end": "0xbfc7ffff",

--- a/tools/fix_duckstation_deps_paths.py
+++ b/tools/fix_duckstation_deps_paths.py
@@ -3,7 +3,7 @@
 The windows-x64 prebuilt archive ships with CMake-generated Targets files that
 have `_IMPORT_PREFIX` baked in as an absolute path from wherever the archive
 was originally extracted. When the project root moves (e.g. psxrecomp-projects
--> psxrecomp-v4), CMake can't find the referenced .lib/.dll files even though
+-> psxrecomp), CMake can't find the referenced .lib/.dll files even though
 they're there.
 
 This script rewrites `OLD_PREFIX` -> `NEW_PREFIX` in every file under
@@ -12,7 +12,7 @@ This script rewrites `OLD_PREFIX` -> `NEW_PREFIX` in every file under
 import os, sys
 
 OLD = b"psxrecomp-projects"
-NEW = b"psxrecomp-v4"
+NEW = b"psxrecomp"
 ROOT = sys.argv[1] if len(sys.argv) > 1 else "duckstation/dep/prebuilt"
 
 n_files = 0

--- a/tools/gen_phase2_seeds.py
+++ b/tools/gen_phase2_seeds.py
@@ -63,7 +63,7 @@ for addr_int, s in sorted(old_seeds.items()):
         preserved += 1
 
 result = {
-    "schema": "psxrecomp-v4 phase2 seeds",
+    "schema": "psxrecomp phase2 seeds",
     "source": "generated/ghidra_function_starts.json + phase1c seeds + dispatch_miss_seeds + preserved manual",
     "seed_count": len(seeds),
     "seeds": seeds,

--- a/tools/scan_branch_delay_hazards.py
+++ b/tools/scan_branch_delay_hazards.py
@@ -418,7 +418,7 @@ def main():
     )
 
     out = {
-        "schema": "psxrecomp-v4 phase1b branch_delay_hazards v2",
+        "schema": "psxrecomp phase1b branch_delay_hazards v2",
         "program": cfg.name,
         "totals": {
             "branches_scanned":                  branch_count,
@@ -472,7 +472,7 @@ def verify_translator_uses_snapshots():
          and never reads cpu->gpr[ in the c_code body.
     Returns a dict { branch_name -> {pass: bool, reason: str} }.
     """
-    # strict_translator.cpp lives in psxrecomp-v4 regardless of which
+    # strict_translator.cpp lives in psxrecomp regardless of which
     # program config is being audited. Resolve relative to this script.
     psxrecomp_root = Path(__file__).parent.parent
     src_path = psxrecomp_root / "recompiler" / "src" / "strict_translator.cpp"

--- a/tools/scan_f2_sites.py
+++ b/tools/scan_f2_sites.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-rom = open('F:/Projects/psxrecomp-v4/bios/SCPH1001.BIN','rb').read()
+rom = open('F:/Projects/psxrecomp/bios/SCPH1001.BIN','rb').read()
 
 matches = []
 for rt in range(32):
@@ -46,7 +46,7 @@ for addr, rt, op, rs, rt_out, imm, nw, offset in matches:
 # Read dispatch.c:
 print("\n--- Functions containing 0xF2000003 sites ---")
 import re
-dispatch = open('F:/Projects/psxrecomp-v4/generated/SCPH1001_dispatch.c').read()
+dispatch = open('F:/Projects/psxrecomp/generated/SCPH1001_dispatch.c').read()
 entries = re.findall(r'\{\s*0x([0-9A-F]+)u,\s*func_([0-9A-F]+)\s*\}', dispatch)
 # Only keep those in code range (phys 0x1FC00000+)
 fn_list = sorted([(int(a,16), name) for a,name in entries])


### PR DESCRIPTION
## Summary

Four improvements landed together on this branch, all verified working on Windows via the Tomba! release build:

- **psxrecomp-v4 naming fully retired.** Every identifier (`PSXRECOMP_V4_ROOT`, `PSXRECOMP_V4_RUNTIME_SOURCES`, `psxrecomp_v4_add_runtime_target`, `PSXRECOMP_V4_*_H` include guards), log string, schema tag, and tool path updated. CMake variable is now `PSXRECOMP_ROOT`; cmake function is `psxrecomp_add_runtime_target`. Game repos reference the shared tool via a junction named `psxrecomp`.

- **Release/debug build split.** `PSX_DEBUG_TOOLS` defaults **OFF** for `Release`/`MinSizeRel` and **ON** for `Debug`/`RelWithDebInfo`. A plain `-DCMAKE_BUILD_TYPE=Release` now produces a lean production binary with no TCP debug server, no freeze heartbeat ring dumps, and no per-block recording. Debug builds are unchanged. Release MinGW adds `-mwindows` (no console window); Release MSVC adds `/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup`.

- **Resizable window.** `SDL_WINDOW_RESIZABLE` added to `SDL_CreateWindow`. `SDL_RenderSetLogicalSize(640, 480)` (from the Mac PR) letterboxes correctly at any window size. F11 / Alt+Enter / Cmd+F still toggles fullscreen.

- **Windows fiber conversion fix.** `psx_fiber_convert_thread` on Windows dropped the `0x1E00000000000000` TEB sentinel and now calls `ConvertThreadToFiber` first, using `GetLastError() == ERROR_ALREADY_FIBER` to detect the already-converted case. The sentinel is an MSVC-internal value not guaranteed by MinGW's `GetCurrentFiber()` implementation. On MinGW the old check silently skipped `ConvertThreadToFiber`, leaving the main thread as a non-fiber, and the first `SwitchToFiber` (during BIOS CD-boot at frame ~714) produced a SIGSEGV. The fix matches the pre-abstraction behaviour from the old `psx_current_host_fiber` which gated on `s_main_fiber == NULL`.

## Test plan

- [x] Tomba! (`build-local-release/psx-runtime.exe`) boots past PS logo into gameplay — previously SIGSEGV at frame 714
- [x] `Subsystem: Windows GUI` confirmed via `objdump -p` — no console window
- [x] Memory card loads correctly from `TombaRecomp/saves/` — save state preserved
- [x] Window is resizable; fullscreen toggle (F11) works
- [x] Debug build (`PSX_DEBUG_TOOLS=ON`) unchanged — TCP server still binds on port 4470

🤖 Generated with [Claude Code](https://claude.com/claude-code)