### PR TITLE
debug_server: use _DARWIN_C_SOURCE on macOS (fixes INADDR_LOOPBACK build error)

### DIFF
--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -9,7 +9,9 @@
  */
 /* Expose POSIX clock_gettime()/CLOCK_MONOTONIC (used by monotonic_ms) on
  * glibc — must precede any system header. Harmless on Windows/macOS. */
-#ifndef _POSIX_C_SOURCE
+#ifdef __APPLE__
+#  define _DARWIN_C_SOURCE 1   /* full BSD+POSIX namespace: clock_gettime AND INADDR_LOOPBACK/timeval */
+#elif !defined(_POSIX_C_SOURCE)
 #  define _POSIX_C_SOURCE 200809L
 #endif
 #include <time.h>


### PR DESCRIPTION
On macOS, `_POSIX_C_SOURCE` hides BSD symbols (`INADDR_LOOPBACK`, `struct timeval`), so `debug_server.c` fails to compile with clang. Switch to `_DARWIN_C_SOURCE` on Apple (full BSD+POSIX namespace, keeps `clock_gettime`), matching the guard already in `psx_fiber.c`. Required for the native macOS (arm64) build of psx-runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)