### PR TITLE
Recognize boot executables in nested disc paths

### DIFF
--- a/runtime/src/disc_identity.cpp
+++ b/runtime/src/disc_identity.cpp
@@ -130,6 +130,8 @@ std::string scan_boot_serial(const std::vector<uint8_t>& buf) {
             j++;
             if (token.size() > 32) break;
         }
+        const size_t slash = token.find_last_of("\\/");
+        if (slash != std::string::npos) token = token.substr(slash + 1);
         const std::string norm = normalize_serial(token);
         if (!norm.empty()) return norm;
     }


### PR DESCRIPTION
## Summary

Some PS1 discs put the boot executable below a directory in `SYSTEM.CNF`, e.g. `cdrom:\TEKKEN3\SLUS_004.02;1`. The disc identity scanner was passing the whole path token into serial normalization, so serial/region detection could miss the actual executable serial.

This PR strips any `/` or `\` directory prefix before calling `normalize_serial()`.

## Verification

- Verified in a local Tekken 3 bring-up: runtime detected `disc region NTSC-U (serial SLUS-00402)` from a nested boot path.
- Attempted a clean upstream worktree build on macOS, but CMake is blocked in this shell because `pkg-config` cannot locate `sdl2.pc`.

## Scope

Game-neutral parser fix only. No game data, generated code, or per-title override tables.
